### PR TITLE
Fixed .gitignore file exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.idea/
 /.mypy_cache/
-/external/
+/external/*
 /venv/
+
+!external/__init__.py

--- a/external/__init__.py
+++ b/external/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3 -B
+# coding=utf-8
+
+"""
+Copyright (C) 2019-2024 Plato Mavropoulos
+"""


### PR DESCRIPTION
Restore "external" directory by excluding the placeholder `__init__.py` file within